### PR TITLE
fix download and index data parsing problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 config/env.yml
+/gbfs

--- a/download.js
+++ b/download.js
@@ -1,5 +1,8 @@
-const fs = require('fs')
+const fs = require('fs-extra')
 const fetch = require('isomorphic-fetch')
+
+const DBL_QUOTE = '"'
+const COMMA = ','
 
 getSystems()
 
@@ -7,26 +10,43 @@ function getSystems () {
   return fetch('https://raw.githubusercontent.com/NABSA/gbfs/master/systems.csv')
     .then((res) => res.text())
     .then((csv) => {
-      fs.writeFileSync('./gbfs/systems.csv', csv)
+      // NOTE: fs-extra outputFileSync will create dirs that don't exist
+      fs.outputFileSync('./gbfs/systems.csv', csv)
       csv
         .split('\n')
         .slice(1, -1)
         .map((row) => {
-          const quotes = row.split('"')
-          return [...quotes[0].slice(0, -1).split(','), quotes[1], ...quotes[2].slice(1).split(',')]
+          const quotes = row.split(DBL_QUOTE)
+          // FYI: breaks on non-double-quoted location
+          //return [...quotes[0].slice(0, -1).split(','), quotes[1], ...quotes[2].slice(1).split(',')]
+          if (quotes.length == 3) {
+            // handle the case with double-quoted location:
+            const first = quotes[0].split(COMMA)
+            const last = quotes[2].split(COMMA)
+            return [
+              first[0],
+              first[1],       // ignore last comma in first chunk
+              quotes[1],  // use middle chunk from quotes split
+              last[1],       // ignore first comma in last chunk
+              last[2],
+              last[3]
+            ]
+          } else {
+            // standard un-quoted location
+            return row.split(COMMA)
+          }
         })
         .map((row) => {
           return {
             country: row[0],
-            gbfs: row[5],
-            id: row[3],
-            location: row[2],
             name: row[1],
-            url: row[4]
+            location: row[2],
+            id: row[3],
+            url: row[4],
+            gbfs: row[5]
           }
         })
         .forEach((system) => {
-          if (!fs.existsSync(`./gbfs/${system.id}`)) fs.mkdirSync(`./gbfs/${system.id}`)
           fetch(system.gbfs)
             .then((res) => res.json())
             .then((gbfs) => {
@@ -55,7 +75,7 @@ function getSystems () {
 
 function write (id, name, data) {
   return new Promise((resolve, reject) => {
-    fs.writeFile(`./gbfs/${id}/${name}.json`, JSON.stringify(data, null, '\t'), (err) => {
+    fs.outputFile(`./gbfs/${id}/${name}.json`, JSON.stringify(data, null, '\t'), (err) => {
       if (err) return reject(err)
       resolve()
     })

--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@ import turfExtent from 'turf-extent'
 
 import './style.css'
 
+const DBL_QUOTE = '"'
+const COMMA = ','
+
 const root = document.getElementById('root')
 
 root.innerHTML = `
@@ -39,6 +42,7 @@ systemsSelect.onchange = function (event) {
 }
 
 function selectSystem (id) {
+  
   const System = Systems[id]
 
   systemInfo.innerHTML = Object.keys(System).map((key) => {
@@ -76,17 +80,34 @@ function getSystems () {
         .split('\n')
         .slice(1, -1)
         .map((row) => {
-          const quotes = row.split('"')
-          return [...quotes[0].slice(0, -1).split(','), quotes[1], ...quotes[2].slice(1).split(',')]
+          const quotes = row.split(DBL_QUOTE)
+          // FYI: breaks on non-double-quoted location
+          //return [...quotes[0].slice(0, -1).split(','), quotes[1], ...quotes[2].slice(1).split(',')]
+          if (quotes.length == 3) {
+            // handle the case with double-quoted location:
+            const first = quotes[0].split(COMMA)
+            const last = quotes[2].split(COMMA)
+            return [
+              first[0],
+              first[1],       // ignore last comma in first chunk
+              quotes[1],  // use middle chunk from quotes split
+              last[1],       // ignore first comma in last chunk
+              last[2],
+              last[3]
+            ]
+          } else {
+            // standard un-quoted location
+            return row.split(COMMA)
+          }
         })
         .forEach((row) => {
           Systems[row[3]] = {
             country: row[0],
-            gbfs: row[5],
-            id: row[3],
-            location: row[2],
             name: row[1],
-            url: row[4]
+            location: row[2],
+            id: row[3],
+            url: row[4],
+            gbfs: row[5]
           }
         })
     })
@@ -100,7 +121,6 @@ function updateStations (System, infoUrl) {
     .then((res) => res.json())
     .then((gbfs) => {
       System.geojson = gbfs2geojson(gbfs)
-
       map.addSource(System.id, {
         cluster: true,
         clusterRadius: 25,

--- a/package.json
+++ b/package.json
@@ -15,9 +15,8 @@
   ],
   "author": "Conveyal",
   "license": "MIT",
-  "engineStrict": true,
   "engines": {
-    "node": ">= 6"
+    "node": ">=6.0"
   },
   "devDependencies": {
     "fs-extra": "^0.30.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Show GBFS stations to a GeoJSON feature collection.",
   "main": "index.js",
   "scripts": {
-    "download": "babel-node download.js --presets es2015,stage-2",
+    "download": "node download.js",
     "start": "mastarm serve --config config",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -15,10 +15,11 @@
   ],
   "author": "Conveyal",
   "license": "MIT",
+  "engineStrict": true,
+  "engines": {
+    "node": ">= 6"
+  },
   "devDependencies": {
-    "babel-cli": "^6.9.0",
-    "babel-preset-es2015": "^6.9.0",
-    "babel-preset-stage-2": "^6.5.0",
     "fs-extra": "^0.30.0",
     "mastarm": "0.0.9"
   },

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Show GBFS stations to a GeoJSON feature collection.",
   "main": "index.js",
   "scripts": {
+    "download": "babel-node download.js --presets es2015,stage-2",
     "start": "mastarm serve --config config",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -15,6 +16,10 @@
   "author": "Conveyal",
   "license": "MIT",
   "devDependencies": {
+    "babel-cli": "^6.9.0",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-stage-2": "^6.5.0",
+    "fs-extra": "^0.30.0",
     "mastarm": "0.0.9"
   },
   "dependencies": {


### PR DESCRIPTION
1- update package.json for babel code and script 'download'
2- use 'fs-extra' to auto-create dirs when missing during download process
3- update parse logic to handle case where location was double-quoted in download data
4- ignore /gbfs dir in repo

on fresh repo checkout, you can now:

npm install && npm run download && npm start

to get up-and-running
